### PR TITLE
RDKEMW-8862: test coverity

### DIFF
--- a/ttsclient/TextToSpeechService.cpp
+++ b/ttsclient/TextToSpeechService.cpp
@@ -84,6 +84,7 @@ void TextToSpeechService::registerSpeechEventHandlers()
         subscribe("onnetworkerror", onNetworkError, this);
         subscribe("onplaybackerror", onPlaybackError, this);
         subscribe("onspeechcomplete", onSpeechComplete, this);
+        /*dummy text to check coverity*/
     }
 }
 


### PR DESCRIPTION
Reason for change: need to address coding guidelines in TTS
Test Procedure: Mentioned in ticket
Risks: Low